### PR TITLE
time-series cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ USER $USER
 WORKDIR $HOME
 
 COPY --chown=$USER:$USER /target/app.jar app.jar
-CMD ["sh", "-c", "java -jar -XX:+UseZGC \
+CMD ["sh", "-c", "java -jar -Xmx2g -XX:+UseZGC \
          -Dorg.xerial.snappy.use.systemlib=true \
          -Dorg.xerial.snappy.lib.path=/usr/lib/libsnappy.so.1 \
          $JAVA_OPTS app.jar"]

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: fdk-statistics-service
   annotations:
-    nginx.ingress.kubernetes.io/limit-rpm: '10'
+    nginx.ingress.kubernetes.io/limit-rps: '4'
     nginx.ingress.kubernetes.io/limit-burst-multiplier: '2'
     nginx.ingress.kubernetes.io/limit-whitelist: '10.0.0.0/8,162.244.5.0/24'
     nginx.ingress.kubernetes.io/server-snippet: |

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>

--- a/src/main/kotlin/no/digdir/fdk/statistics/Scheduler.kt
+++ b/src/main/kotlin/no/digdir/fdk/statistics/Scheduler.kt
@@ -29,6 +29,9 @@ open class Scheduler(private val statisticsService: StatisticsService) {
                 endExclusive = LocalDate.now()
             )
         )
+
+        log.info("Calculation done, clearing time-series cache")
+        statisticsService.clearTimeSeriesCache()
     }
 
 }

--- a/src/main/kotlin/no/digdir/fdk/statistics/configuration/CacheConfig.kt
+++ b/src/main/kotlin/no/digdir/fdk/statistics/configuration/CacheConfig.kt
@@ -1,0 +1,29 @@
+package no.digdir.fdk.statistics.configuration
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+@EnableCaching
+open class CacheConfig {
+
+    @Bean
+    open fun caffeineConfig(): Caffeine<Any, Any> {
+        return Caffeine.newBuilder()
+            .maximumSize(10000)
+            .expireAfterWrite(1, TimeUnit.DAYS)
+    }
+
+    @Bean
+    open fun cacheManager(caffeine: Caffeine<Any, Any>): CacheManager {
+        val caffeineCacheManager = CaffeineCacheManager()
+        caffeineCacheManager.setCaffeine(caffeine)
+        return caffeineCacheManager
+    }
+
+}

--- a/src/main/kotlin/no/digdir/fdk/statistics/model/DTO.kt
+++ b/src/main/kotlin/no/digdir/fdk/statistics/model/DTO.kt
@@ -27,7 +27,7 @@ data class TimeSeriesFilters(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class SearchFilter<T>(
+data class SearchFilter<T>(
     val value: T
 )
 

--- a/src/main/kotlin/no/digdir/fdk/statistics/service/StatisticsService.kt
+++ b/src/main/kotlin/no/digdir/fdk/statistics/service/StatisticsService.kt
@@ -145,6 +145,8 @@ class StatisticsService(private val statisticsRepository: StatisticsRepository) 
             }
     }
 
+    fun clearTimeSeriesCache() = statisticsRepository.clearTimeSeriesCache()
+
     fun timeSeries(req: TimeSeriesRequest): List<TimeSeriesPoint> {
         logger.debug("Building time series for request: {}", req)
         req.validate()


### PR DESCRIPTION
resolve #19 

Første spørring tar noen sekunder, og etter det svarer den på samme spørring på ~50ms

La til 10 000 som maks antall cachede elementer, kan ikke se for meg at det er lavt ved normal bruk. De kan vare i 24 timer, men alt tømmes uansett når den oppdaterer latest-tabellen hver natt.

Kan ikke se noe nevneverdig endring i ressursbruk når jeg manuelt sender en del diverse spørringer. Kan kjøre et script som klarer å makse grensen på 10 000 neste uke, se hvordan ressursbruken blir da.